### PR TITLE
refactor of event,category viewset for non logged in users

### DIFF
--- a/PersonalPlannerAPI/views/category.py
+++ b/PersonalPlannerAPI/views/category.py
@@ -2,6 +2,7 @@ from rest_framework import viewsets, status
 from rest_framework import serializers
 from rest_framework.response import Response
 from PersonalPlannerAPI.models import Category
+from rest_framework.permissions import AllowAny 
 
 class CategorySerializer(serializers.ModelSerializer):
     class Meta:
@@ -10,6 +11,8 @@ class CategorySerializer(serializers.ModelSerializer):
 
 
 class CategoryViewSet(viewsets.ViewSet):
+    permission_classes = [AllowAny]
+    
     def list(self, request):
         categories = Category.objects.all()
         serializer = CategorySerializer(categories, many=True)

--- a/PersonalPlannerAPI/views/events.py
+++ b/PersonalPlannerAPI/views/events.py
@@ -5,6 +5,7 @@ from PersonalPlannerAPI.models import Category, Event, PPUser
 from .users import PPUserSerializer
 from .category import CategorySerializer
 from rest_framework import permissions
+from rest_framework.permissions import AllowAny 
 
 class EventSerializer(serializers.ModelSerializer):
     user = PPUserSerializer(many=False)
@@ -35,7 +36,8 @@ class EventSerializer(serializers.ModelSerializer):
         extra_kwargs = {"description": {"required": False}, "date_posted": {"read_only": True}}
 
 class EventViewSet(viewsets.ViewSet):
-    permission_classes = [permissions.IsAuthenticated]
+    # permission_classes = [permissions.IsAuthenticated]
+    permission_classes = [AllowAny]
 
     def list(self, request):
         events = Event.objects.all()


### PR DESCRIPTION
## Pull Request: Refactor Viewsets for Non-Logged-In Users

### Modified Files:
- `PersonalPlannerAPI/views/category.py`
- `PersonalPlannerAPI/views/events.py`

### Description:

This pull request updates the viewsets for categories and events in the PersonalPlannerAPI to handle non-logged-in users more effectively. It ensures that certain functionalities are accessible even without authentication, improving the user experience and overall usability of the API.

### Additional Notes:
- Ensure that the changes do not compromise security or violate any authentication requirements.
- Test thoroughly to verify that the viewsets behave as expected for both authenticated and non-authenticated users.
