### PR TITLE
added headcount

### DIFF
--- a/PersonalPlannerAPI/views/events.py
+++ b/PersonalPlannerAPI/views/events.py
@@ -13,6 +13,10 @@ class EventSerializer(serializers.ModelSerializer):
     is_owner = serializers.SerializerMethodField()
     category = CategorySerializer(many=False)
     attendees = PPUserSerializer(many=True, read_only=True)
+    attendees_count = serializers.SerializerMethodField()
+    
+    def get_attendees_count(self, obj):
+        return obj.attendees.count()
 
     def get_is_owner(self, obj):
         return self.context["request"].user == obj.user.user
@@ -33,7 +37,8 @@ class EventSerializer(serializers.ModelSerializer):
             "address",
             "zipcode",
             "is_owner",
-            "attendees" 
+            "attendees",
+            "attendees_count"
         ]
 
         extra_kwargs = {"description": {"required": False}, "date_posted": {"read_only": True}}


### PR DESCRIPTION
added ad hoc property to the `evetns.py page and **To test** `git fetch` inside of main. copy and pasta my branch- now inside our events.py. There is an ad hoc property that is grabbing the attendees count. Now we can dynamically see how many attendees are coming to each event in the front end using this. 