### PR TITLE
refactor to userviewset for ppusers

### DIFF
--- a/PersonalPlanner/urls.py
+++ b/PersonalPlanner/urls.py
@@ -25,6 +25,9 @@ from PersonalPlannerAPI.views import (
 router = DefaultRouter(trailing_slash=False)
 router.register(r"categories", CategoryViewSet, basename="category")
 router.register(r"events", EventViewSet, basename="event")
+router.register(r"ppusers", PPUserViewSet, basename="ppuser") 
+ 
+
 urlpatterns = [
     path("", include(router.urls)),
     path("login", PPUserViewSet.as_view({"post": "login_user"}), name="login"),

--- a/PersonalPlannerAPI/Test_data.py
+++ b/PersonalPlannerAPI/Test_data.py
@@ -1,4 +1,4 @@
-User
+# User
 
 !!!register
 
@@ -21,13 +21,13 @@ User
     "password": "your_password"
 }
 
-Category
+# Category
 
 {
     "label": "outdoor",
 }
 
-Create Events
+# Create Events
 
 {
   "category": 1,
@@ -41,7 +41,7 @@ Create Events
   "zipcode": 12345
 }
 
-Update of Events
+# Update of Events
 
 {
   "user": 1,
@@ -54,4 +54,26 @@ Update of Events
   "state": "TN",
   "address": "1234 Sample St",
   "zipcode": 11111
+}
+
+# get all, get id of PPusers
+# http://localhost:8000/ppusers
+# http://localhost:8000/ppusers/3
+
+
+# structure of Update of PPusers -pending
+{
+    "id": 3,
+    "user": {
+        "id": 3,
+        # only include username if updating to new value
+        "username": "michelle", 
+        "first_name": "Chelle",
+        "last_name": "Totherow",
+        "email": "michelle@email.com"
+    },
+    "city": "Madison",
+    "state": "TN",
+    "address": "2134 this address",
+    "zipcode": 37115
 }

--- a/PersonalPlannerAPI/views/users.py
+++ b/PersonalPlannerAPI/views/users.py
@@ -14,15 +14,28 @@ class UserSerializer(serializers.ModelSerializer):
         extra_kwargs = {"password": {"write_only": True}}
 
 class PPUserSerializer(serializers.ModelSerializer):
-    
+    user = UserSerializer()
     class Meta:
         model = PPUser
-        fields = ( 'id','city', 'state', 'address', 'zipcode')
+        fields = ( 'id','user','city', 'state', 'address', 'zipcode')
 
 class PPUserViewSet(viewsets.ViewSet):
     queryset = User.objects.all()
     permission_classes = [permissions.AllowAny]
     serializer_class = UserSerializer
+    
+    def list(self, request):
+        pp_users = PPUser.objects.all()
+        serializer = PPUserSerializer(pp_users, many=True)
+        return Response(serializer.data, status=status.HTTP_200_OK)
+    
+    def retrieve(self, request, pk=None):
+        try:
+            pp_user_instance = PPUser.objects.get(pk=pk)
+            serializer = PPUserSerializer(pp_user_instance)
+            return Response(serializer.data, status=status.HTTP_200_OK)
+        except PPUser.DoesNotExist:
+            return Response(status=status.HTTP_404_NOT_FOUND)
 
     @action(detail=False, methods=['post'], url_path='register')
     def register_account(self, request):


### PR DESCRIPTION
Refactor to Use ViewSet for ppusers

#### This pull request includes refactoring to use ViewSet for ppusers in the PersonalPlannerAPI project. Here's a summary of the changes:

### 1. Modified urls.py:
   - Updated routing to utilize ViewSet for ppusers.

### 2. Modified Test_data.py:
   - Made adjustments to accommodate changes related to ViewSet usage for ppusers.

### 3. Modified users.py in views:
   - Refactored code to integrate ViewSet for ppusers.

### These updates allow Postman get all or get by id and include user as object nested in PPuser ViewSet.




